### PR TITLE
Remove Storm DB

### DIFF
--- a/uc/uc.go
+++ b/uc/uc.go
@@ -162,8 +162,8 @@ func (ucdb *UncagedDB) removeEntry(searchType ucdbSearchType, value interface{})
 // initDB initialises the database with a new booklist
 func (ucdb *UncagedDB) initDB(bl []BookCountDetails) {
 	ucdb.booklist = bl
-	for _, b := range ucdb.booklist {
-		b.PriKey = ucdb.newPriKey()
+	for i := range ucdb.booklist {
+		ucdb.booklist[i].PriKey = ucdb.newPriKey()
 	}
 }
 

--- a/uc/uctypes.go
+++ b/uc/uctypes.go
@@ -25,12 +25,11 @@ import (
 	"io"
 	"net"
 	"time"
-
-	"github.com/asdine/storm"
 )
 
 type calOpCode int
 type calMsgCode int
+type ucdbSearchType int
 
 // Calibre opcodes
 const (
@@ -62,11 +61,16 @@ const (
 	MESSAGE_SHOW_TOAST     = 3
 )
 
+// ucdb search types
+const (
+	PriKey ucdbSearchType = iota
+	Lpath
+)
+
 // UncagedDB is the structure used by UNCaGED's internal database
 type UncagedDB struct {
-	PriKey int    `storm:"id,increment"`
-	Lpath  string `storm:"index,unique"`
-	UUID   string `storm:"index,unique"`
+	nextKey  int
+	booklist []BookCountDetails
 }
 
 // Client is the interface that specific implementations of UNCaGED must implement.
@@ -118,16 +122,15 @@ type calConn struct {
 		calibreVers    string
 		calibreLibUUID string
 	}
-	metadata       []map[string]interface{}
-	NewMetadata    []map[string]interface{}
-	DelMetadata    []map[string]interface{}
-	bookList       []BookCountDetails
+	// metadata       []map[string]interface{}
+	// NewMetadata    []map[string]interface{}
+	// DelMetadata    []map[string]interface{}
 	deviceInfo     DeviceInfo
 	okStr          string
 	serverPassword string
 	tcpConn        net.Conn
 	tcpReader      *bufio.Reader
-	db             *storm.DB
+	ucdb           *UncagedDB
 	client         Client
 	transferCount  int
 }
@@ -235,10 +238,10 @@ type BookCount struct {
 // on device
 type BookCountDetails struct {
 	PriKey       int       `json:"priKey"`
-	UUID         string    `json:"uuid"`
-	Extension    string    `json:"extension"`
-	Lpath        string    `json:"lpath"`
-	LastModified time.Time `json:"last_modified"`
+	UUID         string    `json:"uuid" mapstructure:"uuid"`
+	Extension    string    `json:"extension" mapstructure:"extension"`
+	Lpath        string    `json:"lpath" mapstructure:"lpath"`
+	LastModified time.Time `json:"last_modified" mapstructure:"last_modified"`
 }
 
 // GetBook prepares Calibre for the book we are about to send

--- a/uc/uctypes.go
+++ b/uc/uctypes.go
@@ -122,9 +122,6 @@ type calConn struct {
 		calibreVers    string
 		calibreLibUUID string
 	}
-	// metadata       []map[string]interface{}
-	// NewMetadata    []map[string]interface{}
-	// DelMetadata    []map[string]interface{}
 	deviceInfo     DeviceInfo
 	okStr          string
 	serverPassword string


### PR DESCRIPTION
It turns out a persistent DB is not required. Calibre still requires mapping books to "primary keys", but only in the context of the current session.

Permanent DB management should be left to the client applications.